### PR TITLE
Fixed indentation for generate_input_long_history2 and refactoring

### DIFF
--- a/data/foursquare_structure.txt
+++ b/data/foursquare_structure.txt
@@ -1,0 +1,48 @@
+data_neural (used for training the NN)
+    - <User ID>
+        -- sessions
+            --- key (str), value (list)
+                ---- key : session id (str)
+                ---- value: check-in (pair of location-time) (list)
+        -- train_loc
+            --- key (str), value (list of list)
+                ---- key: location ID
+                ---- value : number of visit in the training set
+        -- train --> list of session id used for training ?
+        -- test  --> list of session id used for testing  ?
+        -- explore   : 
+        -- entropy   :
+        -- rg        :
+        -- valid_len : #sessions for testing
+        -- pred_len  : #session for training
+
+data_filter
+    - <User ID>
+        -- session_count
+        -- raw_sessions
+        -- topk
+        -- topk_count
+        -- sessions
+            --- key (str), value (list)
+                ---- key : session id (str)
+                ---- value: check-in (pair of location-time) (list)
+   
+vid_lookup
+    - <Location ID>
+        -- List
+            --- Latitude
+            --- Longitude
+            
+vid_list
+    - key (str), value (list)
+        -- key : original venue id ? (str)
+        -- value : (list) (e.g., [701, 47]) (1st part is the generated venue id, 2nd part is the number of visits)
+        -- Unknown location given a key, value pair [0, -1]
+        
+uid_list
+    - key (str), value (list)
+        -- key : original user id ? (str)
+        -- value : ??? (list) (e.g., [0, 7])
+        
+parameters
+    - Parameters used in the model


### PR DESCRIPTION
1. Refactor the snippet for max aggregation (i.e., line 86-90) using default dict for a simpler logic
https://github.com/vonfeng/DeepMove/blob/0acff5d88d70d31a4fcf580648e0056e103dc6cf/codes/train.py#L86

2. Refactor the snippet for avg aggregation (i.e., line 106-116) using Counter for a simpler logic
https://github.com/vonfeng/DeepMove/blob/0acff5d88d70d31a4fcf580648e0056e103dc6cf/codes/train.py#L106

3. Move the assignment of "history_count" inside the if logic to reduce redundancy
https://github.com/vonfeng/DeepMove/blob/0acff5d88d70d31a4fcf580648e0056e103dc6cf/codes/train.py#L124

4. Refactor the variable "loc_tim" in "generate_input_long_history2" since it is unnecessary

5. Refactor the history, count extraction, and torch_trace

6. Fixed the indentation for "generate_input_long_history2"

7. Added commentary for foursquare dataset structure